### PR TITLE
User Controller Refactor

### DIFF
--- a/app/src/main/java/com/example/impact/model/Admin.java
+++ b/app/src/main/java/com/example/impact/model/Admin.java
@@ -6,6 +6,8 @@ import androidx.annotation.Nullable;
  * Admin user model
  */
 public class Admin extends User {
+
+    public static final String ROLE_KEY = "admin";
     public Admin() {
         // Default constructor for Firestore
     }
@@ -13,4 +15,8 @@ public class Admin extends User {
         super(id, name, email, phone);
     }
 
+    @Override
+    public String getRole() {
+        return ROLE_KEY;
+    }
 }

--- a/app/src/main/java/com/example/impact/model/Admin.java
+++ b/app/src/main/java/com/example/impact/model/Admin.java
@@ -1,5 +1,13 @@
 package com.example.impact.model;
 
-public class Admin {
+import androidx.annotation.Nullable;
+
+public class Admin extends User {
+    public Admin() {
+        // Default constructor for Firestore
+    }
+    public Admin(String id, @Nullable String name, String email, @Nullable String phone) {
+        super(id, name, email, phone);
+    }
 
 }

--- a/app/src/main/java/com/example/impact/model/Entrant.java
+++ b/app/src/main/java/com/example/impact/model/Entrant.java
@@ -7,41 +7,15 @@ import java.io.Serializable;
 /**
  * Represents an entrant using the app and stores their profile information.
  */
-public class Entrant implements Serializable {
-    private String id;
-    private String name;
-    private String email;
-    @Nullable
-    private String phone;
+public class Entrant extends User {
+    private String name; // This is not Nullable for entrants
 
-    /**
-     * Required empty constructor for Firestore deserialization.
-     */
     public Entrant() {
-        // Default constructor required for calls to DataSnapshot.getValue(Entrant.class)
+        // Default constructor for Firestore
     }
 
-    /**
-     * Creates an entrant profile using the provided details.
-     *
-     * @param id    unique identifier for the entrant
-     * @param name  entrant full name
-     * @param email entrant contact email
-     * @param phone optional entrant phone number
-     */
     public Entrant(String id, String name, String email, @Nullable String phone) {
-        this.id = id;
-        this.name = name;
-        this.email = email;
-        this.phone = phone;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
+        super(id, name, email, phone);
     }
 
     public String getName() {
@@ -50,22 +24,5 @@ public class Entrant implements Serializable {
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    @Nullable
-    public String getPhone() {
-        return phone;
-    }
-
-    public void setPhone(@Nullable String phone) {
-        this.phone = phone;
     }
 }

--- a/app/src/main/java/com/example/impact/model/Entrant.java
+++ b/app/src/main/java/com/example/impact/model/Entrant.java
@@ -8,7 +8,8 @@ import java.io.Serializable;
  * Represents an entrant using the app and stores their profile information.
  */
 public class Entrant extends User {
-    private String name; // This is not Nullable for entrants
+
+    public static final String ROLE_KEY = "entrant";
 
     public Entrant() {
         // Default constructor for Firestore
@@ -16,5 +17,10 @@ public class Entrant extends User {
 
     public Entrant(String id, String name, String email, @Nullable String phone) {
         super(id, name, email, phone);
+    }
+
+    @Override
+    public String getRole() {
+        return ROLE_KEY;
     }
 }

--- a/app/src/main/java/com/example/impact/model/Organizer.java
+++ b/app/src/main/java/com/example/impact/model/Organizer.java
@@ -6,11 +6,18 @@ import androidx.annotation.Nullable;
  * Organizer profile model
  */
 public class Organizer extends User {
+
+    public static final String ROLE_KEY = "organizer";
     public Organizer() {
         // Default constructor for Firestore
     }
 
     public Organizer(String id, @Nullable String name, String email, @Nullable String phone) {
         super(id, name, email, phone);
+    }
+
+    @Override
+    public String getRole() {
+        return ROLE_KEY;
     }
 }

--- a/app/src/main/java/com/example/impact/model/Organizer.java
+++ b/app/src/main/java/com/example/impact/model/Organizer.java
@@ -1,4 +1,13 @@
 package com.example.impact.model;
 
-public class Organizer {
+import androidx.annotation.Nullable;
+
+public class Organizer extends User {
+    public Organizer() {
+        // Default constructor for Firestore
+    }
+
+    public Organizer(String id, @Nullable String name, String email, @Nullable String phone) {
+        super(id, name, email, phone);
+    }
 }

--- a/app/src/main/java/com/example/impact/model/User.java
+++ b/app/src/main/java/com/example/impact/model/User.java
@@ -1,0 +1,66 @@
+package com.example.impact.model;
+
+import androidx.annotation.Nullable;
+
+import java.io.Serializable;
+
+public abstract class User implements Serializable {
+    private String id; // Unique id for Users
+    private String email;
+    @Nullable
+    private String name;
+    @Nullable
+    private String phone;
+
+    public User() {
+        // Default constructor for Firestore
+    }
+
+    /**
+     * Creates an User profile using the provided details.
+     *
+     * @param id    unique identifier for the entrant
+     * @param name  entrant full name
+     * @param email entrant contact email
+     * @param phone optional entrant phone number
+     */
+    public User(String id, @Nullable String name, String email, @Nullable String phone) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.phone = phone;
+    }
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    public void setName(@Nullable String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    @Nullable
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(@Nullable String phone) {
+        this.phone = phone;
+    }
+}

--- a/app/src/main/java/com/example/impact/model/User.java
+++ b/app/src/main/java/com/example/impact/model/User.java
@@ -63,4 +63,6 @@ public abstract class User implements Serializable {
     public void setPhone(@Nullable String phone) {
         this.phone = phone;
     }
+
+    public abstract String getRole();
 }

--- a/app/src/main/java/com/example/impact/view/AdminProfileListFragment.java
+++ b/app/src/main/java/com/example/impact/view/AdminProfileListFragment.java
@@ -13,8 +13,10 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.impact.R;
-import com.example.impact.controller.EntrantController;
+import com.example.impact.controller.UserController;
 import com.example.impact.model.Entrant;
+import com.example.impact.model.Organizer;
+import com.example.impact.model.User;
 import com.example.impact.utils.DeletionConfirmationUtil;
 import com.example.impact.view.adapter.AdminProfileAdapter;
 
@@ -26,12 +28,12 @@ import java.util.List;
 public class AdminProfileListFragment extends Fragment implements AdminProfileAdapter.DeleteListener {
 
     private AdminProfileAdapter adapter;
-    private EntrantController entrantController;
+    private UserController userController;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        entrantController = new EntrantController();
+        userController = new UserController();
     }
 
     @Override
@@ -52,15 +54,17 @@ public class AdminProfileListFragment extends Fragment implements AdminProfileAd
      * Requests all entrant profiles from Firestore.
      */
     private void loadProfiles() {
-        entrantController.fetchAllEntrants(this::onProfilesLoaded,
+        userController.fetchAllUsers(
+                List.of(Entrant.ROLE_KEY, Organizer.ROLE_KEY),
+                this::onProfilesLoaded,
                 error -> showToast(R.string.admin_profile_list_error_loading));
     }
 
     /**
      * Supplies fetched profiles to the adapter.
      */
-    private void onProfilesLoaded(List<Entrant> entrants) {
-        adapter.setProfiles(entrants);
+    private void onProfilesLoaded(List<User> users) {
+        adapter.setProfiles(users);
     }
 
     private void onProfileDelete(String name) {
@@ -92,18 +96,18 @@ public class AdminProfileListFragment extends Fragment implements AdminProfileAd
     }
 
     @Override
-    public void onDeleteProfileClicked(int position, Entrant entrant) {
+    public void onDeleteProfileClicked(int position, User user) {
         if (getContext() == null || !isAdded()) {
             return;
         }
-        String displayName = !TextUtils.isEmpty(entrant.getName())
-                ? entrant.getName()
+        String displayName = !TextUtils.isEmpty(user.getName())
+                ? user.getName()
                 : getString(R.string.admin_profile_list_name_placeholder);
 
         DeletionConfirmationUtil confirmation = new DeletionConfirmationUtil(
                 getContext(),
                 displayName,
-                () -> entrantController.deleteProfile(entrant.getId(),
+                () -> userController.deleteProfile(user.getId(),
                         unused -> onProfileDelete(displayName),
                         error -> showToast(R.string.admin_profile_list_error_deletion)));
         confirmation.show();

--- a/app/src/main/java/com/example/impact/view/EntrantProfileActivity.java
+++ b/app/src/main/java/com/example/impact/view/EntrantProfileActivity.java
@@ -11,9 +11,8 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.example.impact.R;
-import com.example.impact.controller.EntrantController;
+import com.example.impact.controller.UserController;
 import com.example.impact.model.Entrant;
-import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 
 /**
@@ -28,7 +27,7 @@ public class EntrantProfileActivity extends AppCompatActivity {
     private Button updateButton;
     private Button deleteButton;
 
-    private EntrantController entrantController;
+    private UserController userController;
     private String entrantId;
     private boolean hasExistingProfile;
 
@@ -37,7 +36,7 @@ public class EntrantProfileActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_entrant_profile);
 
-        entrantController = new EntrantController();
+        userController = new UserController();
 
         nameInput = findViewById(R.id.editTextEntrantName);
         emailInput = findViewById(R.id.editTextEntrantEmail);
@@ -66,7 +65,7 @@ public class EntrantProfileActivity extends AppCompatActivity {
      * Loads any previously saved profile and toggles buttons accordingly.
      */
     private void loadProfile() {
-        entrantController.fetchProfile(entrantId, entrant -> {
+        userController.fetchProfile(entrantId, entrant -> {
             if (entrant != null) {
                 hasExistingProfile = true;
                 nameInput.setText(entrant.getName());
@@ -92,7 +91,7 @@ public class EntrantProfileActivity extends AppCompatActivity {
             Toast.makeText(this, R.string.entrant_profile_saved_message, Toast.LENGTH_SHORT).show();
         };
 
-        executeProfileMutation(() -> entrantController.saveProfileToFirestore(entrant, successListener, error ->
+        executeProfileMutation(() -> userController.saveProfileToFirestore(entrant, successListener, error ->
                 Toast.makeText(this, R.string.entrant_profile_error_save_failed, Toast.LENGTH_SHORT).show()));
     }
 
@@ -108,7 +107,7 @@ public class EntrantProfileActivity extends AppCompatActivity {
         OnSuccessListener<Void> successListener = unused ->
                 Toast.makeText(this, R.string.entrant_profile_update_message, Toast.LENGTH_SHORT).show();
 
-        executeProfileMutation(() -> entrantController.updateProfile(entrant, successListener, error ->
+        executeProfileMutation(() -> userController.updateProfile(entrant, successListener, error ->
                 Toast.makeText(this, R.string.entrant_profile_error_save_failed, Toast.LENGTH_SHORT).show()));
     }
 
@@ -128,7 +127,7 @@ public class EntrantProfileActivity extends AppCompatActivity {
      * Removes the profile document and closes the screen.
      */
     private void deleteProfile(DialogInterface dialogInterface, int which) {
-        entrantController.deleteProfile(entrantId, unused -> {
+        userController.deleteProfile(entrantId, unused -> {
             Toast.makeText(this, R.string.entrant_profile_deleted_message, Toast.LENGTH_SHORT).show();
             finish();
         }, error -> Toast.makeText(this, R.string.entrant_profile_error_save_failed, Toast.LENGTH_SHORT).show());

--- a/app/src/main/java/com/example/impact/view/EventHistoryActivity.java
+++ b/app/src/main/java/com/example/impact/view/EventHistoryActivity.java
@@ -11,7 +11,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.impact.R;
-import com.example.impact.controller.EntrantController;
+import com.example.impact.controller.UserController;
 import com.example.impact.model.EntrantHistoryItem;
 import com.example.impact.view.adapter.EventHistoryAdapter;
 
@@ -23,7 +23,7 @@ import java.util.List;
 public class EventHistoryActivity extends AppCompatActivity {
     public static final String EXTRA_ENTRANT_ID = "entrant_id";
 
-    private EntrantController entrantController;
+    private UserController userController;
     private EventHistoryAdapter historyAdapter;
     private TextView emptyStateView;
     private String entrantId;
@@ -40,7 +40,7 @@ public class EventHistoryActivity extends AppCompatActivity {
             return;
         }
 
-        entrantController = new EntrantController();
+        userController = new UserController();
 
         RecyclerView recyclerView = findViewById(R.id.recyclerViewEventHistory);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
@@ -56,7 +56,7 @@ public class EventHistoryActivity extends AppCompatActivity {
      * Requests the entrant's waiting-list history.
      */
     private void loadHistory() {
-        entrantController.getEntrantHistory(entrantId, this::onHistoryLoaded,
+        userController.getEntrantHistory(entrantId, this::onHistoryLoaded,
                 error -> Toast.makeText(this, R.string.event_history_error_loading, Toast.LENGTH_SHORT).show());
     }
 

--- a/app/src/main/java/com/example/impact/view/adapter/AdminProfileAdapter.java
+++ b/app/src/main/java/com/example/impact/view/adapter/AdminProfileAdapter.java
@@ -10,7 +10,7 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.impact.R;
-import com.example.impact.model.Entrant;
+import com.example.impact.model.User;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,12 +28,12 @@ public class AdminProfileAdapter extends RecyclerView.Adapter<AdminProfileAdapte
          * Called when an admin taps delete on a profile card.
          *
          * @param position adapter position
-         * @param entrant  profile slated for deletion
+         * @param user  profile slated for deletion
          */
-        void onDeleteProfileClicked(int position, Entrant entrant);
+        void onDeleteProfileClicked(int position, User user);
     }
 
-    private final List<Entrant> profiles;
+    private final List<User> profiles;
     private final DeleteListener deleteListener;
 
     /**
@@ -85,7 +85,7 @@ public class AdminProfileAdapter extends RecyclerView.Adapter<AdminProfileAdapte
      *
      * @param newProfiles entrant list to display (may be {@code null})
      */
-    public void setProfiles(List<Entrant> newProfiles) {
+    public void setProfiles(List<User> newProfiles) {
         profiles.clear();
         if (newProfiles != null) {
             profiles.addAll(newProfiles);
@@ -98,6 +98,7 @@ public class AdminProfileAdapter extends RecyclerView.Adapter<AdminProfileAdapte
      */
     class AdminProfileViewHolder extends RecyclerView.ViewHolder {
         final TextView nameTextView;
+        final TextView roleTextView;
         final TextView emailTextView;
         final TextView phoneTextView;
         final TextView idTextView;
@@ -109,6 +110,7 @@ public class AdminProfileAdapter extends RecyclerView.Adapter<AdminProfileAdapte
         AdminProfileViewHolder(@NonNull View itemView) {
             super(itemView);
             nameTextView = itemView.findViewById(R.id.admin_profile_name);
+            roleTextView = itemView.findViewById(R.id.admin_profile_role);
             emailTextView = itemView.findViewById(R.id.admin_profile_email);
             phoneTextView = itemView.findViewById(R.id.admin_profile_phone);
             idTextView = itemView.findViewById(R.id.admin_profile_id);
@@ -118,20 +120,22 @@ public class AdminProfileAdapter extends RecyclerView.Adapter<AdminProfileAdapte
         /**
          * Populates the card with entrant details.
          *
-         * @param entrant  entrant profile bound to the row
+         * @param user user profile bound to the row
          * @param position adapter position
          */
-        void bind(Entrant entrant, int position) {
-            String name = entrant.getName() != null ? entrant.getName() : itemView.getContext().getString(R.string.admin_profile_list_name_placeholder);
-            String email = entrant.getEmail() != null ? entrant.getEmail() : itemView.getContext().getString(R.string.admin_profile_list_email_placeholder);
-            String phone = entrant.getPhone() != null ? entrant.getPhone() : itemView.getContext().getString(R.string.admin_profile_list_phone_placeholder);
+        void bind(User user, int position) {
+            String name = user.getName() != null ? user.getName() : itemView.getContext().getString(R.string.admin_profile_list_name_placeholder);
+            String role = user.getRole() != null ? user.getRole() : "Unknown role";
+            String email = user.getEmail() != null ? user.getEmail() : itemView.getContext().getString(R.string.admin_profile_list_email_placeholder);
+            String phone = user.getPhone() != null ? user.getPhone() : itemView.getContext().getString(R.string.admin_profile_list_phone_placeholder);
 
             nameTextView.setText(name);
+            roleTextView.setText(itemView.getContext().getString(R.string.admin_profile_list_role_format, role));
             emailTextView.setText(itemView.getContext().getString(R.string.admin_profile_list_email_format, email));
             phoneTextView.setText(itemView.getContext().getString(R.string.admin_profile_list_phone_format, phone));
-            idTextView.setText(itemView.getContext().getString(R.string.admin_profile_list_id_format, entrant.getId()));
+            idTextView.setText(itemView.getContext().getString(R.string.admin_profile_list_id_format, user.getId()));
 
-            deleteButton.setOnClickListener(v -> deleteListener.onDeleteProfileClicked(position, entrant));
+            deleteButton.setOnClickListener(v -> deleteListener.onDeleteProfileClicked(position, user));
         }
     }
 }

--- a/app/src/main/res/layout/item_admin_profile.xml
+++ b/app/src/main/res/layout/item_admin_profile.xml
@@ -25,6 +25,15 @@
             android:ellipsize="end" />
 
         <TextView
+            android:id="@+id/admin_profile_role"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textSize="14sp"
+            android:maxLines="1"
+            android:ellipsize="end" />
+
+        <TextView
             android:id="@+id/admin_profile_email"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
     <string name="admin_profile_list_name_placeholder">Unnamed profile</string>
     <string name="admin_profile_list_email_placeholder">No email provided</string>
     <string name="admin_profile_list_phone_placeholder">No phone provided</string>
+    <string name="admin_profile_list_role_format">Role: %1$s</string>
     <string name="admin_profile_list_email_format">Email: %1$s</string>
     <string name="admin_profile_list_phone_format">Phone: %1$s</string>
     <string name="admin_profile_list_id_format">ID: %1$s</string>

--- a/app/src/test/java/com/example/impact/controller/UserControllerTest.java
+++ b/app/src/test/java/com/example/impact/controller/UserControllerTest.java
@@ -22,13 +22,13 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests covering basic entrant controller validation and mapping logic.
  */
-public class EntrantControllerTest {
+public class UserControllerTest {
 
     @Test
     public void buildEntrantData_includesCoreFields() {
         Entrant entrant = new Entrant("id-123", "Sam Sample", "sam@example.com", null);
 
-        Map<String, Object> data = EntrantController.buildEntrantData(entrant);
+        Map<String, Object> data = UserController.buildUserData(entrant);
 
         assertThat(data.get("id"), is("id-123"));
         assertThat(data.get("name"), is("Sam Sample"));
@@ -40,7 +40,7 @@ public class EntrantControllerTest {
     public void buildEntrantData_includesPhoneWhenPresent() {
         Entrant entrant = new Entrant("id-456", "Alex Example", "alex@example.com", "7801234567");
 
-        Map<String, Object> data = EntrantController.buildEntrantData(entrant);
+        Map<String, Object> data = UserController.buildUserData(entrant);
 
         assertThat(data.get("phone"), is("7801234567"));
     }
@@ -49,7 +49,7 @@ public class EntrantControllerTest {
     public void validateEntrant_rejectsMissingName() {
         Entrant entrant = new Entrant("id-456", "", "alex@example.com", null);
 
-        EntrantController.validateEntrant(entrant);
+        UserController.validateUser(entrant);
     }
 
     @Test
@@ -68,10 +68,12 @@ public class EntrantControllerTest {
         QuerySnapshot querySnapshot = mock(QuerySnapshot.class);
         when(querySnapshot.getDocuments()).thenReturn(Arrays.asList(olderSnapshot, newerSnapshot));
 
-        EntrantController controller = new EntrantController(mock(com.google.firebase.firestore.FirebaseFirestore.class));
+        UserController controller = new UserController(mock(com.google.firebase.firestore.FirebaseFirestore.class));
         List<EntrantHistoryItem> items = controller.mapHistory(querySnapshot);
 
         assertThat(items.get(0).getEventId(), is("eventB"));
         assertThat(items.get(1).getEventId(), is("eventA"));
     }
+
+    // TODO test organizer/admin
 }


### PR DESCRIPTION
Refactored the EntrantController class into UserController. This is because we are no longer using a separate "entrants" collection in the DB, and we are now using a "users" collection. Therefor EntrantController should be refactored, as there is no sense in making a separate controller class for each role.

Also merged Orions branch where he created an abstract User class that Entrant, Organizer, and Admin all extend. This allows the UserController implementation to be general and flexible. Methods in the UserController class can simply query for specific roles if they would like specific user models.

Finally, fixed the administrator profile list view. This includes allowing it to display both organizer and entrant profiles. This can be changed if needed.