### PR TITLE
#32 #bugfix: Add optional entrant limit and fix organizer tab routing

### DIFF
--- a/app/src/main/java/com/example/impact/controller/WaitingListController.java
+++ b/app/src/main/java/com/example/impact/controller/WaitingListController.java
@@ -19,8 +19,13 @@ import java.util.Map;
  * Handles operations for joining or leaving event waiting lists.
  */
 public class WaitingListController {
+    static final String COLLECTION_EVENTS = "events";
     private static final String COLLECTION_WAITING_LISTS = "waitingLists";
     private static final String SUB_COLLECTION_ENTRANTS = "entrants";
+    /**
+     * Error code used when the waiting list limit prevents joining.
+     */
+    public static final String ERROR_WAITING_LIST_LIMIT_REACHED = "waiting_list_limit_reached";
 
     private final FirebaseFirestore firestore;
 
@@ -55,15 +60,47 @@ public class WaitingListController {
                                 @Nullable OnSuccessListener<Void> successListener,
                                 @Nullable OnFailureListener failureListener) {
         validateIds(eventId, entrantId);
-
-        Map<String, Object> data = buildWaitingListData(eventId, eventName, entrantId);
-        Task<Void> task = firestore.collection(COLLECTION_WAITING_LISTS)
+        firestore.collection(COLLECTION_EVENTS)
                 .document(eventId)
-                .collection(SUB_COLLECTION_ENTRANTS)
-                .document(entrantId)
-                .set(data);
+                .get()
+                .addOnSuccessListener(eventSnapshot -> {
+                    Long limit = eventSnapshot != null ? eventSnapshot.getLong("maxEntrants") : null;
+                    if (limit == null || limit <= 0) {
+                        writeWaitingListEntry(eventId, eventName, entrantId, successListener, failureListener);
+                        return;
+                    }
+                    final int limitValue = limit.intValue();
 
-        attachListeners(task, successListener, failureListener);
+                    firestore.collection(COLLECTION_WAITING_LISTS)
+                            .document(eventId)
+                            .collection(SUB_COLLECTION_ENTRANTS)
+                            .get()
+                            .addOnSuccessListener(snapshot -> {
+                                boolean alreadyJoined = false;
+                                for (DocumentSnapshot entrantSnapshot : snapshot.getDocuments()) {
+                                    if (entrantId.equals(entrantSnapshot.getId())) {
+                                        alreadyJoined = true;
+                                        break;
+                                    }
+                                }
+
+                                if (alreadyJoined || snapshot.size() < limitValue) {
+                                    writeWaitingListEntry(eventId, eventName, entrantId, successListener, failureListener);
+                                } else if (failureListener != null) {
+                                    failureListener.onFailure(new IllegalStateException(ERROR_WAITING_LIST_LIMIT_REACHED));
+                                }
+                            })
+                            .addOnFailureListener(error -> {
+                                if (failureListener != null) {
+                                    failureListener.onFailure(error);
+                                }
+                            });
+                })
+                .addOnFailureListener(error -> {
+                    if (failureListener != null) {
+                        failureListener.onFailure(error);
+                    }
+                });
     }
 
     /**
@@ -149,6 +186,21 @@ public class WaitingListController {
         data.put("status", "pending");
         data.put("timestamp", FieldValue.serverTimestamp());
         return data;
+    }
+
+    private void writeWaitingListEntry(@NonNull String eventId,
+                                       @NonNull String eventName,
+                                       @NonNull String entrantId,
+                                       @Nullable OnSuccessListener<Void> successListener,
+                                       @Nullable OnFailureListener failureListener) {
+        Map<String, Object> data = buildWaitingListData(eventId, eventName, entrantId);
+        Task<Void> task = firestore.collection(COLLECTION_WAITING_LISTS)
+                .document(eventId)
+                .collection(SUB_COLLECTION_ENTRANTS)
+                .document(entrantId)
+                .set(data);
+
+        attachListeners(task, successListener, failureListener);
     }
 
     /**

--- a/app/src/main/java/com/example/impact/model/Event.java
+++ b/app/src/main/java/com/example/impact/model/Event.java
@@ -26,6 +26,8 @@ public class Event implements Serializable {
     private String qrCodeUrl;
     private String organizerEmail;
     private Integer capacity;
+    @Nullable
+    private Integer maxEntrants;
 
     /**
      * Required empty constructor for Firestore deserialization.
@@ -206,6 +208,21 @@ public class Event implements Serializable {
      */
     public void setCapacity(@Nullable Integer capacity) {
         this.capacity = capacity;
+    }
+
+    /**
+     * @return optional waiting list limit
+     */
+    @Nullable
+    public Integer getMaxEntrants() {
+        return maxEntrants;
+    }
+
+    /**
+     * @param maxEntrants optional waiting list limit
+     */
+    public void setMaxEntrants(@Nullable Integer maxEntrants) {
+        this.maxEntrants = maxEntrants;
     }
 
     /**

--- a/app/src/main/java/com/example/impact/view/EventDetailsFragment.java
+++ b/app/src/main/java/com/example/impact/view/EventDetailsFragment.java
@@ -38,6 +38,7 @@ public class EventDetailsFragment extends Fragment {
     private Button joinButton;
     private Button leaveButton;
     private TextView statusText;
+    private TextView maxEntrantsText;
     private String currentStatus;
 
     /**
@@ -84,6 +85,7 @@ public class EventDetailsFragment extends Fragment {
         TextView nameText = view.findViewById(R.id.textViewEventDetailName);
         TextView dateText = view.findViewById(R.id.textViewEventDetailDate);
         TextView descriptionText = view.findViewById(R.id.textViewEventDetailDescription);
+        maxEntrantsText = view.findViewById(R.id.textViewEventDetailMaxEntrants);
         statusText = view.findViewById(R.id.textViewEventDetailStatus);
         joinButton = view.findViewById(R.id.buttonJoinWaitingList);
         leaveButton = view.findViewById(R.id.buttonLeaveWaitingList);
@@ -91,6 +93,7 @@ public class EventDetailsFragment extends Fragment {
         nameText.setText(event.getName());
         dateText.setText(formatDateRange(event));
         descriptionText.setText(event.getDescription());
+        updateMaxEntrantsLabel();
         currentStatus = getString(R.string.event_status_pending);
         updateStatusLabel();
 
@@ -153,7 +156,13 @@ public class EventDetailsFragment extends Fragment {
             updateStatusLabel();
             setButtonsForJoinedState(true);
             Toast.makeText(requireContext(), R.string.event_details_join_success, Toast.LENGTH_SHORT).show();
-        }, error -> Toast.makeText(requireContext(), R.string.event_details_join_error, Toast.LENGTH_SHORT).show());
+        }, error -> {
+            if (error != null && WaitingListController.ERROR_WAITING_LIST_LIMIT_REACHED.equals(error.getMessage())) {
+                Toast.makeText(requireContext(), R.string.error_event_limit_reached, Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(requireContext(), R.string.event_details_join_error, Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 
     /**
@@ -181,6 +190,15 @@ public class EventDetailsFragment extends Fragment {
      */
     private void updateStatusLabel() {
         statusText.setText(getString(R.string.event_details_status_label, currentStatus));
+    }
+
+    private void updateMaxEntrantsLabel() {
+        if (event.getMaxEntrants() != null) {
+            maxEntrantsText.setVisibility(View.VISIBLE);
+            maxEntrantsText.setText(getString(R.string.event_detail_max_entrants_label, event.getMaxEntrants()));
+        } else if (maxEntrantsText != null) {
+            maxEntrantsText.setVisibility(View.GONE);
+        }
     }
 
     /**

--- a/app/src/main/java/com/example/impact/view/OrganizerActivity.java
+++ b/app/src/main/java/com/example/impact/view/OrganizerActivity.java
@@ -26,12 +26,12 @@ public class OrganizerActivity extends BaseDashboardActivity {
 
     @Override
     protected Fragment getInitialFragment() {
-        return OrganizerEventListFragment.newInstance(organizerId);
+        return OrganizerFragmentFactory.createFragment(R.id.organizer_nav_events, organizerId);
     }
 
     @Override
     protected int getInitialToolbarTitle() {
-        return R.string.admin_nav_events_tab; // This is not a mistake I am just lazy
+        return R.string.organizer_nav_events_tab;
     }
 
     @Override
@@ -41,21 +41,13 @@ public class OrganizerActivity extends BaseDashboardActivity {
 
     @Override
     public Fragment getSelectedFragment(@NonNull int itemId) {
-        if (itemId == R.id.admin_nav_events) {
-            return OrganizerEventListFragment.newInstance(organizerId);
-        } else if (itemId == R.id.organizer_nav_create_event) {
-            return OrganizerCreateEventFragment.newInstance(organizerId);
-        } else if (itemId == R.id.organizer_nav_notifications) {
-//            return OrganizerNotificationsFragment.newInstance(organizerId); // This doesn't exist yet but it will
-            return OrganizerEventListFragment.newInstance(organizerId); // For now just return event view
-        }
-        return null;
+        return OrganizerFragmentFactory.createFragment(itemId, organizerId);
     }
 
     @Override
     public int getSelectedToolBarTitle(@NonNull int itemId) {
-        if (itemId == R.id.admin_nav_events) {
-            return R.string.admin_nav_events_tab; // This is not a mistake I am just lazy
+        if (itemId == R.id.organizer_nav_events) {
+            return R.string.organizer_nav_events_tab;
         } else if (itemId == R.id.organizer_nav_create_event) {
             return R.string.organizer_nav_create_event_tab;
         } else if (itemId == R.id.organizer_nav_notifications) {

--- a/app/src/main/java/com/example/impact/view/OrganizerCreateEventFragment.java
+++ b/app/src/main/java/com/example/impact/view/OrganizerCreateEventFragment.java
@@ -21,6 +21,8 @@ import com.example.impact.R;
 import com.example.impact.controller.EventController;
 import com.example.impact.controller.ImageController;
 import com.example.impact.model.Event;
+import com.example.impact.model.User;
+import com.example.impact.utils.AppSession;
 import com.example.impact.utils.ImageUtil;
 import com.example.impact.utils.QrUtil;
 import com.google.android.material.datepicker.MaterialDatePicker;
@@ -34,7 +36,7 @@ import java.util.Date;
  */
 public class OrganizerCreateEventFragment extends Fragment {
 
-    private EditText etName, etDesc, etCapacity;
+    private EditText etName, etDesc, etCapacity, etMaxEntrants;
     private Button btnStart, btnEnd, btnCreate, btnUploadPoster;
     private ImageView imgQr;
     private Date startDate, endDate;
@@ -70,6 +72,7 @@ public class OrganizerCreateEventFragment extends Fragment {
         etName = v.findViewById(R.id.etEventName);
         etDesc = v.findViewById(R.id.etEventDescription);
         etCapacity = v.findViewById(R.id.etCapacity);
+        etMaxEntrants = v.findViewById(R.id.etMaxEntrants);
         btnStart = v.findViewById(R.id.btnPickStart);
         btnEnd = v.findViewById(R.id.btnPickEnd);
         imgQr = v.findViewById(R.id.imgQrPreview);
@@ -79,6 +82,13 @@ public class OrganizerCreateEventFragment extends Fragment {
 
         if (getArguments() != null) {
             organizerEmail = getArguments().getString("organizerEmail");
+        }
+
+        if (organizerEmail == null) {
+            User currentUser = AppSession.getUser();
+            if (currentUser != null) {
+                organizerEmail = currentUser.getEmail();
+            }
         }
 
         if (organizerEmail == null) {
@@ -189,6 +199,21 @@ public class OrganizerCreateEventFragment extends Fragment {
             if (!TextUtils.isEmpty(cap)) capacity = Integer.parseInt(cap);
         } catch (NumberFormatException ignored) { }
 
+        Integer maxEntrants = null;
+        try {
+            String limitInput = etMaxEntrants.getText().toString().trim();
+            if (!TextUtils.isEmpty(limitInput)) {
+                maxEntrants = Integer.parseInt(limitInput);
+                if (maxEntrants <= 0) {
+                    toast("Waiting list limit must be positive");
+                    return;
+                }
+            }
+        } catch (NumberFormatException ignored) {
+            toast("Waiting list limit must be positive");
+            return;
+        }
+
         Event e = new Event();
         e.setName(name);
         e.setDescription(etDesc.getText().toString().trim());
@@ -196,6 +221,7 @@ public class OrganizerCreateEventFragment extends Fragment {
         e.setEndDate(endDate);     // US 02.01.04
         e.setOrganizerEmail(organizerEmail);
         e.setCapacity(capacity);
+        e.setMaxEntrants(maxEntrants);
 
         if (uploadedImageId != null) {
             e.setPosterUrl(uploadedImageId);   // ensure Event has a posterUrl field

--- a/app/src/main/java/com/example/impact/view/OrganizerFragmentFactory.java
+++ b/app/src/main/java/com/example/impact/view/OrganizerFragmentFactory.java
@@ -1,0 +1,35 @@
+package com.example.impact.view;
+
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.example.impact.R;
+
+/**
+ * Produces organizer dashboard fragments for a selected navigation tab.
+ */
+final class OrganizerFragmentFactory {
+
+    private OrganizerFragmentFactory() {
+        // Utility class
+    }
+
+    /**
+     * Creates the fragment corresponding to the selected organizer menu item.
+     *
+     * @param itemId      selected bottom navigation identifier
+     * @param organizerId optional organizer identifier needed by certain fragments
+     * @return fragment configured for the tab or {@code null} if no mapping exists
+     */
+    @Nullable
+    static Fragment createFragment(int itemId, @Nullable String organizerId) {
+        if (itemId == R.id.organizer_nav_events) {
+            return OrganizerEventListFragment.newInstance(organizerId);
+        } else if (itemId == R.id.organizer_nav_create_event) {
+            return OrganizerCreateEventFragment.newInstance(organizerId);
+        } else if (itemId == R.id.organizer_nav_notifications) {
+            return OrganizerNotificationsFragment.newInstance(organizerId);
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/com/example/impact/view/OrganizerNotificationsFragment.java
+++ b/app/src/main/java/com/example/impact/view/OrganizerNotificationsFragment.java
@@ -1,0 +1,45 @@
+package com.example.impact.view;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.example.impact.R;
+
+/**
+ * Displays organizer notifications (placeholder until backend wiring is complete).
+ */
+public class OrganizerNotificationsFragment extends Fragment {
+
+    private static final String ARG_ORGANIZER_ID = "organizer_id";
+
+    /**
+     * @param organizerId organizer identifier propagated via arguments
+     * @return configured fragment instance
+     */
+    @NonNull
+    public static OrganizerNotificationsFragment newInstance(@Nullable String organizerId) {
+        OrganizerNotificationsFragment fragment = new OrganizerNotificationsFragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_ORGANIZER_ID, organizerId);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_organizer_notifications, container, false);
+        TextView message = view.findViewById(R.id.text_notifications_placeholder);
+        message.setText(getString(R.string.organizer_nav_notifications_tab));
+        return view;
+    }
+}

--- a/app/src/main/res/layout/fragment_event_details.xml
+++ b/app/src/main/res/layout/fragment_event_details.xml
@@ -31,6 +31,14 @@
             android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
 
         <TextView
+            android:id="@+id/textViewEventDetailMaxEntrants"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:visibility="gone"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+
+        <TextView
             android:id="@+id/textViewEventDetailStatus"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_organizer_notifications.xml
+++ b/app/src/main/res/layout/fragment_organizer_notifications.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/text_notifications_placeholder"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+        android:textColor="@android:color/darker_gray" />
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_organizer_tools.xml
+++ b/app/src/main/res/layout/fragment_organizer_tools.xml
@@ -23,6 +23,12 @@
             android:inputType="number"
             android:layout_width="match_parent" android:layout_height="wrap_content"/>
 
+        <EditText
+            android:id="@+id/etMaxEntrants"
+            android:hint="@string/event_field_max_entrants"
+            android:inputType="number"
+            android:layout_width="match_parent" android:layout_height="wrap_content"/>
+
         <Button
             android:id="@+id/btnPickStart"
             android:text="Select Registration Start"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,9 @@
     <string name="event_details_leave_success">Left waiting list</string>
     <string name="event_details_join_error">Could not join waiting list</string>
     <string name="event_details_leave_error">Could not leave waiting list</string>
+    <string name="event_field_max_entrants">Waiting list limit (optional)</string>
+    <string name="error_event_limit_reached">Waiting list is full</string>
+    <string name="event_detail_max_entrants_label">Waiting list limit: %1$d</string>
     <string name="event_details_error_missing_data">Missing event information</string>
     <string name="event_details_status_label">Status: %1$s</string>
     <string name="event_status_selected">selected</string>
@@ -49,6 +52,7 @@
     <string name="main_seed_demo_success">Demo events created</string>
     <string name="main_seed_demo_failure">Unable to create demo events</string>
     <string name="organizer_dashboard_title">Organizer Dashboard</string>
+    <string name="organizer_nav_events_tab">Events</string>
     <string name="organizer_nav_create_event_tab">New Event</string>
     <string name="organizer_nav_notifications_tab">Notifications</string>
     <string name="organizer_tools_placeholder">Organizer Tools Page Placeholder</string>

--- a/app/src/test/java/com/example/impact/controller/WaitingListLimitTest.java
+++ b/app/src/test/java/com/example/impact/controller/WaitingListLimitTest.java
@@ -1,0 +1,93 @@
+package com.example.impact.controller;
+
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Ensures the waiting list controller respects organizer-defined limits.
+ */
+public class WaitingListLimitTest {
+
+    @Test
+    public void joinWaitingList_stopsWhenLimitReached() {
+        FirebaseFirestore firestore = mock(FirebaseFirestore.class);
+        CollectionReference eventsCollection = mock(CollectionReference.class);
+        DocumentReference eventDocument = mock(DocumentReference.class);
+        Task<DocumentSnapshot> eventTask = mock(Task.class);
+
+        when(firestore.collection("events")).thenReturn(eventsCollection);
+        when(eventsCollection.document("event-1")).thenReturn(eventDocument);
+        when(eventDocument.get()).thenReturn(eventTask);
+
+        final OnSuccessListener<DocumentSnapshot>[] eventSuccessHolder = new OnSuccessListener[1];
+        doAnswer(invocation -> {
+            eventSuccessHolder[0] = invocation.getArgument(0);
+            return eventTask;
+        }).when(eventTask).addOnSuccessListener(any());
+        when(eventTask.addOnFailureListener(any())).thenReturn(eventTask);
+
+        CollectionReference waitingLists = mock(CollectionReference.class);
+        DocumentReference waitingListDocument = mock(DocumentReference.class);
+        CollectionReference entrantsCollection = mock(CollectionReference.class);
+        DocumentReference entrantDocument = mock(DocumentReference.class);
+        Task<QuerySnapshot> entrantsTask = mock(Task.class);
+
+        when(firestore.collection("waitingLists")).thenReturn(waitingLists);
+        when(waitingLists.document("event-1")).thenReturn(waitingListDocument);
+        when(waitingListDocument.collection("entrants")).thenReturn(entrantsCollection);
+        when(entrantsCollection.document("entrant-9")).thenReturn(entrantDocument);
+        when(entrantsCollection.get()).thenReturn(entrantsTask);
+
+        final OnSuccessListener<QuerySnapshot>[] entrantsSuccessHolder = new OnSuccessListener[1];
+        doAnswer(invocation -> {
+            entrantsSuccessHolder[0] = invocation.getArgument(0);
+            return entrantsTask;
+        }).when(entrantsTask).addOnSuccessListener(any());
+        when(entrantsTask.addOnFailureListener(any())).thenReturn(entrantsTask);
+
+        WaitingListController controller = new WaitingListController(firestore);
+        OnSuccessListener<Void> successListener = mock(OnSuccessListener.class);
+        OnFailureListener failureListener = mock(OnFailureListener.class);
+
+        controller.joinWaitingList("event-1", "Demo", "entrant-9", successListener, failureListener);
+
+        DocumentSnapshot eventSnapshot = mock(DocumentSnapshot.class);
+        when(eventSnapshot.getLong("maxEntrants")).thenReturn(2L);
+        eventSuccessHolder[0].onSuccess(eventSnapshot);
+
+        QuerySnapshot entrantSnapshot = mock(QuerySnapshot.class);
+        DocumentSnapshot existingOne = mock(DocumentSnapshot.class);
+        when(existingOne.getId()).thenReturn("entrant-1");
+        DocumentSnapshot existingTwo = mock(DocumentSnapshot.class);
+        when(existingTwo.getId()).thenReturn("entrant-2");
+        when(entrantSnapshot.size()).thenReturn(2);
+        when(entrantSnapshot.getDocuments()).thenReturn(Arrays.asList(existingOne, existingTwo));
+        entrantsSuccessHolder[0].onSuccess(entrantSnapshot);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(failureListener).onFailure(exceptionCaptor.capture());
+        assertThat(exceptionCaptor.getValue().getMessage(), is(WaitingListController.ERROR_WAITING_LIST_LIMIT_REACHED));
+        verify(successListener, never()).onSuccess(any());
+        verify(entrantDocument, never()).set(any());
+    }
+}

--- a/app/src/test/java/com/example/impact/view/OrganizerFragmentFactoryTest.java
+++ b/app/src/test/java/com/example/impact/view/OrganizerFragmentFactoryTest.java
@@ -1,0 +1,22 @@
+package com.example.impact.view;
+
+import androidx.fragment.app.Fragment;
+
+import com.example.impact.R;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Verifies organizer tab selections map to the proper fragments.
+ */
+public class OrganizerFragmentFactoryTest {
+
+    @Test
+    public void createFragment_returnsEventsFragment() {
+        Fragment fragment = OrganizerFragmentFactory.createFragment(R.id.organizer_nav_events, "org-1");
+        assertThat(fragment, instanceOf(OrganizerEventListFragment.class));
+    }
+}


### PR DESCRIPTION
Organizers can now optionally limit how many entrants may join the waiting list. A new numeric field is stored and loaded using existing controller methods, no duplicate firestore logic was created. UI updates follow current pattern and include basic validation.

Also fixed a dashboard bug where the Events tab showed an empty screen and the Notifications tab loaded the wrong fragment. Correct tab IDs were mapped to the proper fragments inside the organizer dashboard so each tab now loads the correct view.

Both changes follow existing code style with Javadoc and minimal edits. Tests for entrant limits and fragment routing are included but need to be run locally after Java setup.