### PR TITLE
#102 - Replace organizerEmail with organizerId throughout organizer flow

### DIFF
--- a/app/src/main/java/com/example/impact/controller/EventController.java
+++ b/app/src/main/java/com/example/impact/controller/EventController.java
@@ -120,18 +120,18 @@ public class EventController {
     }
 
     /**
-     * Subscribes to real-time updates for events owned by an organizer email.
+     * Subscribes to real-time updates for events owned by an organizer id.
      *
-     * @param email organizer email address
+     * @param organizerId organizer uid
      * @param listener callback invoked with snapshot updates
      * @return listener registration to dispose of updates
      */
     public ListenerRegistration listenEventsByOrganizer(
-            @NonNull String email,
+            @NonNull String organizerId,
             @NonNull EventListener<QuerySnapshot> listener) {
 
         return firestore.collection("events")
-                .whereEqualTo("organizerEmail", email)
+                .whereEqualTo("organizerId", organizerId)
                 .addSnapshotListener(listener);
     }
 

--- a/app/src/main/java/com/example/impact/model/Event.java
+++ b/app/src/main/java/com/example/impact/model/Event.java
@@ -248,9 +248,10 @@ public class Event implements Serializable {
         if (organizerId != null) data.put("organizerId", organizerId);
         if (organizerEmail != null) data.put("organizerEmail", organizerEmail);
         if (capacity != null) data.put("capacity", capacity);
+        data.put("lottery_done", lottery_done);
         return data;
-     * @return whether the lottery already ran for this event
-     */
+    }
+
     /**
      * Firestore-compatible accessor for {@code lottery_done}.
      */
@@ -305,6 +306,12 @@ public class Event implements Serializable {
         if (doc.contains("organizerId")) {
             String organizerUid = doc.getString("organizerId");
             e.setOrganizerId(organizerUid);
+        }
+        if (doc.contains("lottery_done")) {
+            Boolean lotteryDoneField = doc.getBoolean("lottery_done");
+            if (lotteryDoneField != null) {
+                e.setLottery_done(lotteryDoneField);
+            }
         }
 
         return e;

--- a/app/src/main/java/com/example/impact/model/Event.java
+++ b/app/src/main/java/com/example/impact/model/Event.java
@@ -7,7 +7,9 @@ import com.google.firebase.firestore.DocumentSnapshot;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents an event that entrants can view and join waiting lists for.
@@ -24,6 +26,10 @@ public class Event implements Serializable {
     private String posterUrl;
     private List<String> tags = new ArrayList<>();
     private String qrCodeUrl;
+    private String organizerId;
+    /**
+     * @deprecated Use {@link #organizerId} as the canonical organizer identifier.
+     */
     private String organizerEmail;
     private Integer capacity;
 
@@ -179,6 +185,21 @@ public class Event implements Serializable {
     }
 
     /**
+     * @return organizer id tied to the event
+     */
+    @Nullable
+    public String getOrganizerId() {
+        return organizerId;
+    }
+
+    /**
+     * @param organizerId Firestore identifier of the organizer
+     */
+    public void setOrganizerId(@Nullable String organizerId) {
+        this.organizerId = organizerId;
+    }
+
+    /**
      * @return organizer email tied to the event
      */
     @Nullable
@@ -209,6 +230,26 @@ public class Event implements Serializable {
     }
 
     /**
+     * Serializes this event into a map for Firestore writes.
+     *
+     * @return mutable map representation of the event
+     */
+    public Map<String, Object> toMap() {
+        Map<String, Object> data = new HashMap<>();
+        if (name != null) data.put("name", name);
+        if (description != null) data.put("description", description);
+        if (startDate != null) data.put("startDate", startDate);
+        if (endDate != null) data.put("endDate", endDate);
+        if (posterUrl != null) data.put("posterUrl", posterUrl);
+        data.put("tags", tags != null ? tags : new ArrayList<>());
+        if (qrCodeUrl != null) data.put("qrCodeUrl", qrCodeUrl);
+        if (organizerId != null) data.put("organizerId", organizerId);
+        if (organizerEmail != null) data.put("organizerEmail", organizerEmail);
+        if (capacity != null) data.put("capacity", capacity);
+        return data;
+    }
+
+    /**
      * Populates an event from a Firestore snapshot.
      *
      * @param snapshot Firestore document
@@ -228,6 +269,10 @@ public class Event implements Serializable {
         if (doc.contains("posterUrl")) {
             String poster = doc.getString("posterUrl");
             e.setPosterUrl(poster);
+        }
+        if (doc.contains("organizerId")) {
+            String organizerUid = doc.getString("organizerId");
+            e.setOrganizerId(organizerUid);
         }
 
         return e;

--- a/app/src/main/java/com/example/impact/view/OrganizerCreateEventFragment.java
+++ b/app/src/main/java/com/example/impact/view/OrganizerCreateEventFragment.java
@@ -21,6 +21,7 @@ import com.example.impact.R;
 import com.example.impact.controller.EventController;
 import com.example.impact.controller.ImageController;
 import com.example.impact.model.Event;
+import com.example.impact.utils.AppSession;
 import com.example.impact.utils.ImageUtil;
 import com.example.impact.utils.QrUtil;
 import com.google.android.material.datepicker.MaterialDatePicker;
@@ -47,7 +48,7 @@ public class OrganizerCreateEventFragment extends Fragment {
     private final ActivityResultLauncher<String> pickImageLauncher =
             registerForActivityResult(new ActivityResultContracts.GetContent(), this::onImagePicked);
 
-    String organizerEmail = null; // Fix this to use the AppSession
+    String organizerId = null;
 
     public static final String EXTRA_ORGANIZER_ID = "organizer_id";
 
@@ -78,11 +79,14 @@ public class OrganizerCreateEventFragment extends Fragment {
         imgPosterPreview = v.findViewById(R.id.imgPosterPreview);
 
         if (getArguments() != null) {
-            organizerEmail = getArguments().getString("organizerEmail");
+            organizerId = getArguments().getString(EXTRA_ORGANIZER_ID);
+        }
+        if (TextUtils.isEmpty(organizerId)) {
+            organizerId = AppSession.getUserId();
         }
 
-        if (organizerEmail == null) {
-            Toast.makeText(requireContext(), "Organizer email missing", Toast.LENGTH_SHORT).show();
+        if (organizerId == null) {
+            Toast.makeText(requireContext(), "Organizer id missing", Toast.LENGTH_SHORT).show();
             btnCreate.setEnabled(false);
         } else {
             btnCreate.setEnabled(true);
@@ -194,7 +198,7 @@ public class OrganizerCreateEventFragment extends Fragment {
         e.setDescription(etDesc.getText().toString().trim());
         e.setStartDate(startDate); // US 02.01.04
         e.setEndDate(endDate);     // US 02.01.04
-        e.setOrganizerEmail(organizerEmail);
+        e.setOrganizerId(organizerId);
         e.setCapacity(capacity);
 
         if (uploadedImageId != null) {

--- a/app/src/main/java/com/example/impact/view/OrganizerEventListFragment.java
+++ b/app/src/main/java/com/example/impact/view/OrganizerEventListFragment.java
@@ -6,7 +6,6 @@ import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -19,7 +18,6 @@ import com.example.impact.R;
 import com.example.impact.controller.EventController;
 import com.example.impact.model.Event;
 import com.example.impact.model.Organizer;
-import com.example.impact.model.User;
 import com.example.impact.utils.AppSession;
 import com.example.impact.view.adapter.EventAdapter;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -37,7 +35,7 @@ public class OrganizerEventListFragment extends Fragment implements EventAdapter
     private final EventController controller = new EventController();
     private final ImageController imageController = new ImageController();
     private EventAdapter adapter;
-    private String organizerEmail = "";
+    private String organizerId = "";
     private ListenerRegistration reg;
     private com.example.impact.model.Event eventBeingUpdatedPoster;
     private final androidx.activity.result.ActivityResultLauncher<String> posterPickerLauncher =
@@ -85,17 +83,14 @@ public class OrganizerEventListFragment extends Fragment implements EventAdapter
         rv.setLayoutManager(new LinearLayoutManager(requireContext()));
 
         if (getArguments() != null) {
-            organizerEmail = getArguments().getString("organizerEmail");
+            organizerId = getArguments().getString(EXTRA_ORGANIZER_ID);
         }
-        if (TextUtils.isEmpty(organizerEmail)) {
-            User currentUser = AppSession.getUser();
-            if (currentUser != null) {
-                organizerEmail = currentUser.getEmail();
-            }
+        if (TextUtils.isEmpty(organizerId)) {
+            organizerId = AppSession.getUserId();
         }
 
-        if (organizerEmail == null) {
-            Toast.makeText(requireContext(), "Organizer email missing", Toast.LENGTH_SHORT).show();
+        if (TextUtils.isEmpty(organizerId)) {
+            Toast.makeText(requireContext(), "Organizer id missing", Toast.LENGTH_SHORT).show();
             return v;
         }
 
@@ -104,17 +99,15 @@ public class OrganizerEventListFragment extends Fragment implements EventAdapter
 
         FirebaseFirestore db = AppSession.db();
 
-        // Step 1: verify that this email belongs to an organizer
+        // Step 1: verify that this id belongs to an organizer
         db.collection("users")
-                .whereEqualTo("email", organizerEmail)
-                .whereEqualTo("role", "organizer")
-                .limit(1)
+                .document(organizerId)
                 .get()
-                .addOnSuccessListener(users -> {
-                    if (!users.isEmpty()) {
+                .addOnSuccessListener(userDoc -> {
+                    if (userDoc.exists() && Organizer.ROLE_KEY.equals(userDoc.getString("role"))) {
                         // Step 2: load events for this organizer
                         reg = db.collection("events")
-                                .whereEqualTo("organizerEmail", organizerEmail)
+                                .whereEqualTo("organizerId", organizerId)
                                 .addSnapshotListener((snap, err) -> {
                                     if (err != null || snap == null) return;
                                     List<Event> events = controller.mapEvents(snap);

--- a/app/src/main/java/com/example/impact/view/adapter/OrganizerPagerAdapter.java
+++ b/app/src/main/java/com/example/impact/view/adapter/OrganizerPagerAdapter.java
@@ -1,7 +1,5 @@
 package com.example.impact.view.adapter;
 
-import android.os.Bundle;
-
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
@@ -16,15 +14,15 @@ import com.example.impact.view.OrganizerEventListFragment;
 public class OrganizerPagerAdapter extends FragmentStateAdapter {
 
     private static final int PAGE_COUNT = 2;
-    private final String organizerEmail;
+    private final String organizerId;
 
     /**
      * @param fragmentActivity host activity
-     * @param organizerEmail email used to scope organizer data
+     * @param organizerId organizer uid used to scope organizer data
      */
-    public OrganizerPagerAdapter(@NonNull FragmentActivity fragmentActivity, String organizerEmail) {
+    public OrganizerPagerAdapter(@NonNull FragmentActivity fragmentActivity, String organizerId) {
         super(fragmentActivity);
-        this.organizerEmail = organizerEmail;
+        this.organizerId = organizerId;
     }
     // position 0 = EVENTS, position 1 = CREATE
     /**
@@ -35,18 +33,10 @@ public class OrganizerPagerAdapter extends FragmentStateAdapter {
      */
     @Override @NonNull
     public Fragment createFragment(int position) {
-        Fragment fragment;
         if (position == 0) {
-            fragment = new OrganizerEventListFragment();
-        } else {
-            fragment = new OrganizerCreateEventFragment();
-        }  // <-- create form
-
-        Bundle args = new Bundle();
-        args.putString("organizerEmail", organizerEmail);
-        fragment.setArguments(args);
-
-        return fragment;
+            return OrganizerEventListFragment.newInstance(organizerId);
+        }
+        return OrganizerCreateEventFragment.newInstance(organizerId);
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,7 +49,7 @@
     <string name="event_details_run_lottery_success">Lottery results published</string>
     <string name="event_details_run_lottery_error">Unable to run lottery</string>
     <string name="event_details_waiting_list_count">Total entrants: %1$d</string>
-    <string name="event_details_lottery_criteria">Lottery rules:\n• Entrants may join the waiting list until the enrollment end date.\n• The organizer runs a lottery after enrollment closes.\n• The lottery randomly selects entrants to receive invitations.\n• Selected entrants must accept or decline their invitation.\n• Declining or cancellation triggers selection of replacement entrants.</string>
+    <string name="event_details_lottery_criteria">Lottery rules:\n• Entrants may enroll only until the event’s end date.\n• The organizer manually runs the lottery after enrollment closes.\n• The lottery randomly selects entrants up to the event’s capacity.\n• Selected entrants receive an invitation and must accept or decline.\n• Declining (or being cancelled by the organizer) triggers a redraw.\n• Redraw selects a replacement randomly from remaining non-selected entrants.</string>
     <string name="event_qr_invalid">Invalid QR code</string>
     <string name="event_qr_not_found">Event not found</string>
     <string name="event_qr_fetch_error">Unable to load event details</string>
@@ -112,6 +112,15 @@
     <string name="admin_profile_list_email_format">Email: %1$s</string>
     <string name="admin_profile_list_phone_format">Phone: %1$s</string>
     <string name="admin_profile_list_id_format">ID: %1$s</string>
+    <string name="waiting_list_lottery_criteria">Lottery rules:\n• Entrants may enroll only until the event’s end date.\n• The organizer manually runs the lottery after enrollment closes.\n• The lottery randomly selects entrants up to the event’s capacity.\n• Selected entrants receive an invitation and must accept or decline.\n• Declining (or being cancelled by the organizer) triggers a redraw.\n• Redraw selects a replacement randomly from remaining non-selected entrants.</string>
+    <string name="waiting_list_pending_header">Pending Entrants</string>
+    <string name="waiting_list_empty_pending">No pending entrants</string>
+    <string name="waiting_list_selected_header">Selected Entrants</string>
+    <string name="waiting_list_empty_selected">No selected entrants</string>
+    <string name="waiting_list_cancelled_header">Cancelled Entrants</string>
+    <string name="waiting_list_empty_cancelled">No cancelled entrants</string>
+    <string name="waiting_list_accepted_header">Accepted Entrants</string>
+    <string name="waiting_list_empty_accepted">No accepted entrants</string>
     <string name="entrant_dashboard_title">Entrant Dashboard</string>
     <string name="delete_dialog_text">Are you sure you want to delete %1$s? This action cannot be undone.</string>
     <string name="image_content_description">Event Poster Image</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,7 +46,7 @@
     <string name="event_details_decline_success">Invitation declined</string>
     <string name="event_details_decline_error">Unable to decline invitation</string>
     <string name="event_details_waiting_list_count">Total entrants: %1$d</string>
-    <string name="event_details_lottery_criteria">Lottery rules:\n• Earliest pending entrants are selected when spots open.\n• Selected entrants must accept or decline.\n• Declining promotes the next pending entrant.</string>
+    <string name="event_details_lottery_criteria">Lottery rules:\n• Entrants may join the waiting list until the enrollment end date.\n• The organizer runs a lottery after enrollment closes.\n• The lottery randomly selects entrants to receive invitations.\n• Selected entrants must accept or decline their invitation.\n• Declining or cancellation triggers selection of replacement entrants.</string>
     <string name="event_qr_invalid">Invalid QR code</string>
     <string name="event_qr_not_found">Event not found</string>
     <string name="event_qr_fetch_error">Unable to load event details</string>

--- a/app/src/test/java/com/example/impact/EventTest.java
+++ b/app/src/test/java/com/example/impact/EventTest.java
@@ -1,13 +1,17 @@
 package com.example.impact;
 
 import com.example.impact.model.Event;
+import com.google.firebase.firestore.DocumentSnapshot;
 
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Map;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class EventTest {
 
@@ -68,5 +72,31 @@ public class EventTest {
         assertNull(event.getEndDate());
         assertNull(event.getPosterUrl());
         assertNotNull(event.getTags()); // tags becomes empty list, not null
+    }
+
+    @Test
+    public void testOrganizerIdIsSerialized() {
+        Event event = new Event();
+        event.setOrganizerId("org-123");
+        event.setOrganizerEmail("legacy@mail.com");
+
+        Map<String, Object> data = event.toMap();
+
+        assertEquals("org-123", data.get("organizerId"));
+        assertEquals("legacy@mail.com", data.get("organizerEmail"));
+    }
+
+    @Test
+    public void testFromSnapshotReadsOrganizerId() {
+        DocumentSnapshot snapshot = mock(DocumentSnapshot.class);
+        when(snapshot.toObject(Event.class)).thenReturn(new Event());
+        when(snapshot.getId()).thenReturn("doc-1");
+        when(snapshot.contains("posterUrl")).thenReturn(false);
+        when(snapshot.contains("organizerId")).thenReturn(true);
+        when(snapshot.getString("organizerId")).thenReturn("org-789");
+
+        Event mapped = Event.fromSnapshot(snapshot);
+
+        assertEquals("org-789", mapped.getOrganizerId());
     }
 }


### PR DESCRIPTION
# Implements issue #102: Migrate organizerEmail to organizerId

This PR completes the organizer identifier migration so all organizer-facing features now rely on a UID (`organizerId`) instead of the legacy `organizerEmail` field.

## What was changed

### Event model
* Added `organizerId` with full Javadoc and Firestore serialization.
* Marked `organizerEmail` as `@deprecated` but kept it for backward compatibility.
* Updated `toMap()` and `fromSnapshot()` to include the new field.

### Organizer views
* `OrganizerEventListFragment` now reads `EXTRA_ORGANIZER_ID`, falling back cleanly to `AppSession.getUserId()`.
* Replaced all email-based filtering with UID-based filtering.
* Updated organizer verification to check `/users/{organizerId}` directly.

### Event creation
* `OrganizerCreateEventFragment` now writes `organizerId` when creating new events.
* Removed all calls to `setOrganizerEmail`.

### Pager adapter
* `OrganizerPagerAdapter` now injects `organizerId` into both fragments through `newInstance()` instead of raw bundles.

### EventController
* `listenEventsByOrganizer()` now accepts an organizer UID and queries `.whereEqualTo("organizerId", organizerId)`.

### Tests
* Added serialization/deserialization tests for organizerId.
* Updated existing test cases to expect UID-based fields.

## Why this was needed

The app previously mixed organizerEmail and organizerId, causing inconsistent Firestore data and broken event listing for organizers. With this PR, the codebase consistently uses the UID everywhere.

## Next steps

After merging this PR, we can safely run the database cleanup:
* Copy existing `organizerEmail` to `organizerId` in Firestore.
* Remove the deprecated email field once data is stable.

Entrant-facing flows (event details, waiting list, QR scanning) remain unaffected.