### PR TITLE
Add back button to WaitingListActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,11 @@
             android:name=".view.QrScannerActivity"
             android:exported="false"
             android:screenOrientation="portrait" />
-        <activity android:name=".view.WaitingListActivity" />
+        <activity
+            android:name=".view.WaitingListActivity"
+            android:parentActivityName=".view.OrganizerActivity"
+            >
+        </activity>
         <activity
             android:name=".view.AdminActivity"
             android:exported="false" />

--- a/app/src/main/java/com/example/impact/view/OrganizerEventListFragment.java
+++ b/app/src/main/java/com/example/impact/view/OrganizerEventListFragment.java
@@ -250,6 +250,7 @@ public class OrganizerEventListFragment extends Fragment implements EventAdapter
     public void onViewEntrantsClicked(@NonNull Event event) {
         Intent intent = new Intent(requireContext(), WaitingListActivity.class);
         intent.putExtra("eventId", event.getId());
+        intent.putExtra("eventName", event.getName());
         Integer capacity = event.getCapacity();
         if (capacity != null) {
             intent.putExtra("eventCapacity", capacity);

--- a/app/src/main/java/com/example/impact/view/WaitingListActivity.java
+++ b/app/src/main/java/com/example/impact/view/WaitingListActivity.java
@@ -7,9 +7,11 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.appcompat.widget.Toolbar;
 
 import com.example.impact.R;
 import com.example.impact.controller.WaitingListController;
@@ -53,6 +55,7 @@ public class WaitingListActivity extends AppCompatActivity {
 
     private WaitingListController waitingListController;
     private String eventId;
+    private String eventName;
     @Nullable
     private Integer eventCapacity;
     private boolean lotteryAlreadyRun;
@@ -62,6 +65,8 @@ public class WaitingListActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_waiting_list);
+        Toolbar toolbar = findViewById(R.id.waiting_list_toolbar);
+        setSupportActionBar(toolbar);
 
         waitingListController = new WaitingListController();
         isOrganizer = Organizer.ROLE_KEY.equals(AppSession.getRole());
@@ -84,6 +89,7 @@ public class WaitingListActivity extends AppCompatActivity {
         setupRecycler(R.id.recyclerAcceptedEntrants, acceptedAdapter);
 
         eventId = getIntent().getStringExtra("eventId");
+        eventName = getIntent().getStringExtra("eventName");
         int capacityExtra = getIntent().getIntExtra("eventCapacity", -1);
         eventCapacity = capacityExtra >= 0 ? capacityExtra : null;
         lotteryAlreadyRun = getIntent().getBooleanExtra("lotteryDone", false);
@@ -92,6 +98,12 @@ public class WaitingListActivity extends AppCompatActivity {
             Toast.makeText(this, R.string.event_details_error_missing_data, Toast.LENGTH_SHORT).show();
             finish();
             return;
+        }
+
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setTitle(eventName);
         }
 
         startStatusSubscriptions();

--- a/app/src/main/res/layout/activity_waiting_list.xml
+++ b/app/src/main/res/layout/activity_waiting_list.xml
@@ -1,124 +1,141 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:padding="16dp">
+    android:layout_height="match_parent">
 
-    <LinearLayout
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/waiting_list_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:layout_height="?attr/actionBarSize"
+        android:theme="@style/ThemeOverlay.Material3.Light"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"/>
 
-        <Button
-            android:id="@+id/buttonRunLottery"
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:padding="16dp"
+        app:layout_constraintTop_toBottomOf="@id/waiting_list_toolbar"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/event_details_run_lottery_button"
-            android:visibility="gone" />
+            android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/textViewLotteryCriteria"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:text="@string/waiting_list_lottery_criteria"
-            android:textAppearance="@style/TextAppearance.AppCompat.Small"
-            android:visibility="gone" />
+            <Button
+                android:id="@+id/buttonRunLottery"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/event_details_run_lottery_button"
+                android:visibility="gone" />
 
-        <TextView
-            android:id="@+id/textViewPendingHeader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="@string/waiting_list_pending_header"
-            android:textStyle="bold" />
+            <TextView
+                android:id="@+id/textViewLotteryCriteria"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/waiting_list_lottery_criteria"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                android:visibility="gone" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerPendingEntrants"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:nestedScrollingEnabled="false"
-            android:paddingTop="8dp" />
+            <TextView
+                android:id="@+id/textViewPendingHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/waiting_list_pending_header"
+                android:textStyle="bold" />
 
-        <TextView
-            android:id="@+id/textViewPendingEmpty"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/waiting_list_empty_pending"
-            android:gravity="center"
-            android:padding="8dp"
-            android:visibility="gone" />
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerPendingEntrants"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:nestedScrollingEnabled="false"
+                android:paddingTop="8dp" />
 
-        <TextView
-            android:id="@+id/textViewSelectedHeader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:text="@string/waiting_list_selected_header"
-            android:textStyle="bold" />
+            <TextView
+                android:id="@+id/textViewPendingEmpty"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/waiting_list_empty_pending"
+                android:gravity="center"
+                android:padding="8dp"
+                android:visibility="gone" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerSelectedEntrants"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:nestedScrollingEnabled="false"
-            android:paddingTop="8dp" />
+            <TextView
+                android:id="@+id/textViewSelectedHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/waiting_list_selected_header"
+                android:textStyle="bold" />
 
-        <TextView
-            android:id="@+id/textViewSelectedEmpty"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/waiting_list_empty_selected"
-            android:gravity="center"
-            android:padding="8dp"
-            android:visibility="gone" />
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerSelectedEntrants"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:nestedScrollingEnabled="false"
+                android:paddingTop="8dp" />
 
-        <TextView
-            android:id="@+id/textViewCancelledHeader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:text="@string/waiting_list_cancelled_header"
-            android:textStyle="bold" />
+            <TextView
+                android:id="@+id/textViewSelectedEmpty"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/waiting_list_empty_selected"
+                android:gravity="center"
+                android:padding="8dp"
+                android:visibility="gone" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerCancelledEntrants"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:nestedScrollingEnabled="false"
-            android:paddingTop="8dp" />
+            <TextView
+                android:id="@+id/textViewCancelledHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/waiting_list_cancelled_header"
+                android:textStyle="bold" />
 
-        <TextView
-            android:id="@+id/textViewCancelledEmpty"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/waiting_list_empty_cancelled"
-            android:gravity="center"
-            android:padding="8dp"
-            android:visibility="gone" />
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerCancelledEntrants"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:nestedScrollingEnabled="false"
+                android:paddingTop="8dp" />
 
-        <TextView
-            android:id="@+id/textViewAcceptedHeader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:text="@string/waiting_list_accepted_header"
-            android:textStyle="bold" />
+            <TextView
+                android:id="@+id/textViewCancelledEmpty"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/waiting_list_empty_cancelled"
+                android:gravity="center"
+                android:padding="8dp"
+                android:visibility="gone" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerAcceptedEntrants"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:nestedScrollingEnabled="false"
-            android:paddingTop="8dp" />
+            <TextView
+                android:id="@+id/textViewAcceptedHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/waiting_list_accepted_header"
+                android:textStyle="bold" />
 
-        <TextView
-            android:id="@+id/textViewAcceptedEmpty"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/waiting_list_empty_accepted"
-            android:gravity="center"
-            android:padding="8dp"
-            android:visibility="gone" />
-    </LinearLayout>
-</ScrollView>
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerAcceptedEntrants"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:nestedScrollingEnabled="false"
+                android:paddingTop="8dp" />
+
+            <TextView
+                android:id="@+id/textViewAcceptedEmpty"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/waiting_list_empty_accepted"
+                android:gravity="center"
+                android:padding="8dp"
+                android:visibility="gone" />
+        </LinearLayout>
+    </ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Currently, clicking "View Entrants" in the organizer dashboard brings up the enrolled entrants, but there is no back arrow.
This is a relatively quick fix, I had an old PR that refactored this activity into a fragment; however, that PR is drowned in merge conflicts. This keeps the WaitingListActivity as an activity and adds a toolbar with back button support.
#99 