### PR TITLE
Base navigation icon updates

### DIFF
--- a/app/src/main/java/com/example/impact/view/AdminActivity.java
+++ b/app/src/main/java/com/example/impact/view/AdminActivity.java
@@ -16,7 +16,6 @@ import com.example.impact.utils.AppSession;
  */
 public class AdminActivity extends BaseDashboardActivity {
 
-//    private static final String PLACEHOLDER_ENTRANT_ID = "demo-entrant";
     private String adminId;
 
     @Override

--- a/app/src/main/res/drawable/baseline_image_30.xml
+++ b/app/src/main/res/drawable/baseline_image_30.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="30dp" android:tint="#7E3FF2" android:viewportHeight="24" android:viewportWidth="24" android:width="30dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
+    
+</vector>

--- a/app/src/main/res/layout/activity_base_dashboard.xml
+++ b/app/src/main/res/layout/activity_base_dashboard.xml
@@ -43,6 +43,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?android:attr/windowBackground"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:labelVisibilityMode="labeled" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/admin_nav_menu.xml
+++ b/app/src/main/res/menu/admin_nav_menu.xml
@@ -6,7 +6,7 @@
         android:title="@string/admin_nav_events_tab" />
     <item
         android:id="@+id/admin_nav_images"
-        android:icon="@drawable/outline_article_30"
+        android:icon="@drawable/baseline_image_30"
         android:title="@string/admin_nav_images_tab" />
     <item
         android:id="@+id/admin_nav_profiles"
@@ -14,6 +14,6 @@
         android:title="@string/admin_nav_profiles_tab" />
     <item
         android:id="@+id/admin_nav_notifications"
-        android:icon="@drawable/outline_article_30"
-        android:title="Notifications" />
+        android:icon="@drawable/outline_add_alert_30"
+        android:title="@string/admin_nav_notifications_tab" />
 </menu>


### PR DESCRIPTION
Updates admin base nav icons for images/notifications. Also ensures that admin bottomnav items are always labelled (by default when >3 items, they do not show text in bottom nav).